### PR TITLE
Add ruby regex highlighting

### DIFF
--- a/Dracula.tmTheme
+++ b/Dracula.tmTheme
@@ -150,6 +150,19 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>Ruby Regexp</string>
+			<key>scope</key>
+			<string>source.ruby string.regexp.classic.ruby,source.ruby string.regexp.mod-r.ruby</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#ff5555</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>Keyword</string>
 			<key>scope</key>
 			<string>keyword</string>


### PR DESCRIPTION
Adds red highlighting for regex in Ruby, to better differentiate from regular strings.
### Before & after:

![screen shot 2016-09-02 at 2 35 03 pm](https://cloud.githubusercontent.com/assets/659307/18214373/bd4ca924-711a-11e6-82a0-7d8a2929371e.png)

![screen shot 2016-09-02 at 2 35 22 pm](https://cloud.githubusercontent.com/assets/659307/18214372/bd4bf4c0-711a-11e6-98ae-670659ecfb4f.png)
