### PR TITLE
Fixes PHP syntax highlighting for punctuation.accessor.

### DIFF
--- a/Dracula.tmTheme
+++ b/Dracula.tmTheme
@@ -708,6 +708,19 @@
 				<string>#6272A4</string>
 			</dict>
 		</dict>
+
+		<!-- PHP Tweaks -->
+		<dict>
+			<key>name</key>
+			<string>PHP: Punctuation Accessor</string>
+			<key>scope</key>
+			<string>punctuation.accessor</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#FF79C6</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>83091B89-765E-4F0D-9275-0EC6CB084126</string>


### PR DESCRIPTION
There were some syntax changes in ST3 dev build 3132. The two places I noticed it was in PHP when calling static functions, or functions on an object. The `::` and `->` are white instead of the usual pink-ish color `#FF79C6`.

ST Forum discussion:
https://forum.sublimetext.com/t/dev-build-3132/28529/30

Before:
![before](https://user-images.githubusercontent.com/980089/26892303-7fe3e83e-4b7d-11e7-9c87-df89268f63b3.png)

After:
![after](https://user-images.githubusercontent.com/980089/26892318-87f9d6be-4b7d-11e7-8bc2-74f7805ac046.png)
