### PR TITLE
Add block_caret color

### DIFF
--- a/Dracula.tmTheme
+++ b/Dracula.tmTheme
@@ -25,6 +25,8 @@
 				<string>#282a36</string>
 				<key>caret</key>
 				<string>#f8f8f0</string>
+				<key>block_caret</key>
+				<string>#999a9e</string>
 				<key>foreground</key>
 				<string>#f8f8f2</string>
 				<key>invisibles</key>


### PR DESCRIPTION
# What does this PR do?

It adds a `block_caret` color that is brighter than the `line_highlight` color.


# Why was this PR needed?

When line highlight and block caret is enabled the block caret is invisible since it has the same color as the line highlight.

# Screenshots

## Before this fix
The block caret is not visible since it has the same color as the line highlight:

<img width="407" alt="Skärmavbild 2020-01-30 kl  07 19 22" src="https://user-images.githubusercontent.com/52966/73425136-06841780-4331-11ea-9d64-544a545d7a76.png">


## After this fix

The block caret is visible.

<img width="486" alt="Skärmavbild 2020-01-30 kl  07 18 55" src="https://user-images.githubusercontent.com/52966/73425161-14399d00-4331-11ea-8849-f8ed09cc9b47.png">

